### PR TITLE
Fix TypeScript `node16` and ESM

### DIFF
--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -4,7 +4,7 @@ import type {
   VisitorResult,
   Matches,
   InclusiveDescendant
-} from 'unist-util-visit-parents/complex-types'
+} from 'unist-util-visit-parents'
 
 /**
  * Called when a node (matching test, if given) is found.

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -4,7 +4,7 @@ import type {
   VisitorResult,
   Matches,
   InclusiveDescendant
-} from 'unist-util-visit-parents'
+} from 'unist-util-visit-parents/complex-types.js'
 
 /**
  * Called when a node (matching test, if given) is found.

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * @typedef {import('unist').Parent} Parent
  * @typedef {import('unist-util-is').Test} Test
  * @typedef {import('unist-util-visit-parents').VisitorResult} VisitorResult
- * @typedef {import('./complex-types').Visitor} Visitor
+ * @typedef {import('./complex-types.js').Visitor} Visitor
  */
 
 import {visitParents} from 'unist-util-visit-parents'
@@ -23,15 +23,15 @@ import {visitParents} from 'unist-util-visit-parents'
 export const visit =
   /**
    * @type {(
-   *   (<Tree extends Node, Check extends Test>(tree: Tree, test: Check, visitor: import('./complex-types').BuildVisitor<Tree, Check>, reverse?: boolean) => void) &
-   *   (<Tree extends Node>(tree: Tree, visitor: import('./complex-types').BuildVisitor<Tree>, reverse?: boolean) => void)
+   *   (<Tree extends Node, Check extends Test>(tree: Tree, test: Check, visitor: import('./complex-types.js').BuildVisitor<Tree, Check>, reverse?: boolean) => void) &
+   *   (<Tree extends Node>(tree: Tree, visitor: import('./complex-types.js').BuildVisitor<Tree>, reverse?: boolean) => void)
    * )}
    */
   (
     /**
      * @param {Node} tree
      * @param {Test} test
-     * @param {import('./complex-types').Visitor} visitor
+     * @param {import('./complex-types.js').Visitor} visitor
      * @param {boolean} [reverse]
      */
     function (tree, test, visitor, reverse) {

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "remark-preset-wooorm": "^9.0.0",
     "rimraf": "^3.0.0",
     "tape": "^5.0.0",
-    "tsd": "^0.20.0",
+    "tsd": "^0.22.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": ">=4.7",
     "xo": "^0.49.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@types/unist": "^2.0.0",
     "unist-util-is": "^5.0.0",
-    "unist-util-visit-parents": "^5.0.0"
+    "unist-util-visit-parents": "^5.1.1"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tape": "^5.0.0",
     "tsd": "^0.22.0",
     "type-coverage": "^2.0.0",
-    "typescript": ">=4.7",
+    "typescript": "^4.7.0",
     "xo": "^0.49.0"
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "Node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

See https://github.com/syntax-tree/mdast-util-mdxjs-esm/pull/3.

https://github.com/syntax-tree/unist-util-visit-parents/pull/12 needs to be merged and released before this PR.

<!--do not edit: pr-->
